### PR TITLE
:sparkles: Support specify C++ standard which cppinsights use

### DIFF
--- a/autoload/cppinsights.vim
+++ b/autoload/cppinsights.vim
@@ -13,6 +13,9 @@ call g:cppinsights#utils#plugin.Flag('g:cppinsights#cmd', 'insights')
 ""
 " Configure what window name use for split window. See |%:r|.
 call g:cppinsights#utils#plugin.Flag('g:cppinsights#window_name', '%:r-insights.cpp')
+""
+" Configure C++ standard cppinsights use.
+call g:cppinsights#utils#plugin.Flag('g:cppinsights#cpp_standard', '-std=c++17')
 
 ""
 " Main function for |:Insights|.
@@ -22,7 +25,7 @@ function! cppinsights#main(bang) abort
   else
     let l:null = '/dev/null'
   endif
-  let l:cmd = g:cppinsights#cmd . ' ' . expand('%') . ' 2>' . l:null
+  let l:cmd = g:cppinsights#cmd . ' ' . expand('%') . ' -- ' . g:cppinsights#cpp_standard . ' 2>' . l:null
   try
     let l:text = trim(system(l:cmd))
   catch /^Vim\%((\a\+)\)\=:E677:/

--- a/doc/cppinsights.txt
+++ b/doc/cppinsights.txt
@@ -29,6 +29,10 @@ Default: 'insights' `
 Configure what window name use for split window. See |%:r|.
 Default: '%:r-insights.cpp' `
 
+                                      *cppinsights:g:cppinsights#cpp_standard*
+Configure C++ standard cppinsights use.
+Default: '-std=c++17' `
+
 ==============================================================================
 COMMANDS                                                *cppinsights-commands*
 


### PR DESCRIPTION
Thank you for creating such a great project! I really appreciate the effort you've put into it.

I've submitted a pull request that adds support for specify C++ standard which cppinsights use.

Thanks for taking the time to review my pull request and consider my contribution. If you have any feedback or suggestions, please let me know. I look forward to hearing from you soon!

Best regards.